### PR TITLE
[BUGFIX][DSORG-2040] added suppresswarning phpdoc for unused parameter

### DIFF
--- a/Model/Import/Redirects.php
+++ b/Model/Import/Redirects.php
@@ -111,6 +111,8 @@ class Redirects extends AbstractEntity
     * @param int $rowNum
     *
     * @return bool
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
     */
     public function validateRow(array $rowData, $rowNum): bool
     {


### PR DESCRIPTION
Both parameters are required because the method is inherited from `\Magento\ImportExport\Model\Import\Entity\AbstractEntity`, but phpmd will report that not all parameters are used.
Therefore the SupressWarnings is added to knowingly ignore unused parameters. 